### PR TITLE
Better Detect MetaMask

### DIFF
--- a/src/js/sharedEth/utils.js
+++ b/src/js/sharedEth/utils.js
@@ -47,10 +47,12 @@ function providerType(provider) {
     return PROVIDER_TYPE_COINBASE_WALLET;
   } else if (provider.isImToken) {
     return PROVIDER_TYPE_IM_TOKEN;
-  } else if (provider.isMetaMask && provider.constructor.name === 'MetamaskInpageProvider') {
-    return PROVIDER_TYPE_META_MASK;
-  } else if (provider.isMetaMask && provider.constructor.name === 'InpageBridge') {
-    return PROVIDER_TYPE_META_MASK_MOBILE;
+  } else if (provider.isMetaMask) {
+    if (provider.constructor.name === 'InpageBridge') {
+      return PROVIDER_TYPE_META_MASK_MOBILE;
+    } else {
+      return PROVIDER_TYPE_META_MASK;
+    }
   } else {
     return null;
   }


### PR DESCRIPTION
The constructor on the MetaMask object for me is returning `g`, which indicates the extension is probably being compiled with minification. In that case, we were returning `null` from `providerType` which incorrectly assumed we should then auto-connect. As such, we now always return some variety of MetaMask-type even if we can't positively identify the constructor for mobile versus web.