### PR TITLE
Update ConnectionState with new incoming account

### DIFF
--- a/src/elm/CompoundComponents/Eth/ConnectedEthWallet.elm
+++ b/src/elm/CompoundComponents/Eth/ConnectedEthWallet.elm
@@ -276,16 +276,7 @@ update internalMsg model =
                             model.selectedProvider
 
                 updatedConnectionState =
-                    if
-                        model.connectionState
-                            == Nothing
-                            || model.connectionState
-                            == Just Connecting
-                    then
-                        Just (ConnectedAcct newAccount)
-
-                    else
-                        model.connectionState
+                    Just (ConnectedAcct newAccount)
 
                 updatedChooseWalletState =
                     if model.chooseWalletState == AttemptingConnectToWallet || model.chooseWalletState == ChooseLedgerAccount then


### PR DESCRIPTION
This patch updates `connectionState` when `SetAccount` msg comes in with a new account. Previously, the code was only set the account if the `connectionState` was connecting or not set.