### PR TITLE
Remove node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "fs-extra": "^9.0.0",
     "google-translate": "^3.0.0",
     "html-webpack-plugin": "4.2.1",
-    "node-sass-chokidar": "^1.4.0",
     "postcss-flexbugs-fixes": "^4.2.1",
     "postcss-loader": "3.0.0",
     "promise": "8.1.0",


### PR DESCRIPTION
The downstream projects will use sass compilers (now dart-sass instead of node-sass), so I don't see why _this_ repository should have the dependency. And again, node-sass-chodikar is woah out of date and not what the other repos are using. So this patch removes it from this repo.