### PR TITLE
upgrade markdown package to 7.0.0

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -9,7 +9,7 @@
         "direct": {
             "NoRedInk/elm-json-decode-pipeline": "1.0.0",
             "cmditch/elm-bigint": "1.0.1",
-            "dillonkearns/elm-markdown": "4.0.2",
+            "dillonkearns/elm-markdown": "7.0.0",
             "elm/browser": "1.0.2",
             "elm/bytes": "1.0.8",
             "elm/core": "1.0.5",

--- a/src/elm/CompoundComponents/Utils/Renderer.elm
+++ b/src/elm/CompoundComponents/Utils/Renderer.elm
@@ -264,6 +264,7 @@ navRenderer =
     , blockQuote = empty
     , strong = empty
     , emphasis = empty
+    , strikethrough = empty
     , codeSpan = empty
     , link = empty2
     , image = empty
@@ -295,7 +296,7 @@ navRenderer =
     , tableBody = empty
     , tableRow = empty
     , tableHeaderCell = empty2
-    , tableCell = empty
+    , tableCell = empty2
     }
 
 


### PR DESCRIPTION
the existing version is almost 3 years old and PR to bump to the latest - which includes some markdown formatting fixes