### PR TITLE
add polygon/mumbai networks to components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compound-components",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Compound component library",
   "main": "index.js",
   "scripts": {

--- a/src/elm/CompoundComponents/Eth/Ethereum.elm
+++ b/src/elm/CompoundComponents/Eth/Ethereum.elm
@@ -108,6 +108,11 @@ etherscanUrl network urlValue =
         Goerli ->
             Just ("https://goerli.etherscan.io/" ++ linkType ++ "/" ++ linkValue)
 
+        Polygon ->
+            Just ("https://polygonscan.com/" ++ linkType ++ "/" ++ linkValue)
+
+        Mumbai ->
+            Just ("https://mumbai.polygonscan.com/" ++ linkType ++ "/" ++ linkValue)
         _ ->
             Nothing
 

--- a/src/elm/CompoundComponents/Eth/Network.elm
+++ b/src/elm/CompoundComponents/Eth/Network.elm
@@ -16,6 +16,8 @@ type Network
     | Core
     | Development
     | Unknown
+    | Polygon
+    | Mumbai
 
 
 networkFromId : Int -> Network
@@ -51,11 +53,17 @@ networkFromId networkIdVal =
         99 ->
             Core
 
+        137 ->
+            Polygon
+
         999 ->
             Development
 
         1337 ->
             Development
+
+        80001 ->
+            Mumbai
 
         _ ->
             Unknown
@@ -119,6 +127,12 @@ networkName network =
         Core ->
             "Core"
 
+        Polygon ->
+            "Polygon"
+
+        Mumbai ->
+            "Mumbai"
+
         Development ->
             "Development"
 
@@ -159,8 +173,14 @@ networkId network =
         Core ->
             99
 
+        Polygon ->
+            137
+
         Development ->
             999
+
+        Mumbai ->
+            80001
 
         Unknown ->
             9999
@@ -198,6 +218,12 @@ getEtherscanDomain network =
 
         Core ->
             Nothing
+
+        Polygon ->
+            Just "polygonscan.com"
+
+        Mumbai ->
+            Just "mumbai.polygonscan.com"
 
         Development ->
             Nothing


### PR DESCRIPTION
There is an initiative to support compound's first cross-chain network, Polygon. And this change updates the Networks type to make it more friendly for other Elm frontend repos that rely on these types